### PR TITLE
Add timezone information to EPG data

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="plugin.video.redbulltv" name="Red Bull TV" version="3.2.0" provider-name="nedge2k, andy-g, piejanssens">
   <requires>
+    <import addon="script.module.dateutil" version="2.8.0"/>
     <import addon="script.module.routing" version="0.2.0"/>
     <import addon="xbmc.python" version="2.26.0"/>
   </requires>

--- a/resources/lib/iptvmanager.py
+++ b/resources/lib/iptvmanager.py
@@ -48,19 +48,19 @@ class IPTVManager:
     @via_socket
     def send_epg(self):  # pylint: disable=no-method-argument,no-self-use
         """ Return JSON-EPG formatted information to IPTV Manager. """
-        from redbull import RedBullTV
         from collections import defaultdict
         from datetime import datetime
+        from dateutil.tz import UTC
         from kodiutils import url_for
-
-        epg = defaultdict(list)
+        from redbull import RedBullTV
 
         redbull = RedBullTV()
 
+        epg = defaultdict(list)
         for item in redbull.get_epg().get('items'):
             epg['redbulltv'].append(dict(
-                start=datetime.strptime(item.get('start_time'), "%Y-%m-%dT%H:%M:%S.%fZ").isoformat(),
-                stop=datetime.strptime(item.get('end_time'), "%Y-%m-%dT%H:%M:%S.%fZ").isoformat(),
+                start=datetime.strptime(item.get('start_time'), "%Y-%m-%dT%H:%M:%S.%fZ").replace(tzinfo=UTC).isoformat(),
+                stop=datetime.strptime(item.get('end_time'), "%Y-%m-%dT%H:%M:%S.%fZ").replace(tzinfo=UTC).isoformat(),
                 title=item.get('title'),
                 description=item.get('long_description'),
                 subtitle=item.get('subheading'),


### PR DESCRIPTION
This adds the required timezone information to the EPG data as
pvr.iptvsimple fails if it is missing on Leia.

This fixes add-ons/service.iptv.manager#23 for this add-on.