### PR TITLE
Make use of git archive

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,10 +13,6 @@ ifdef release
 else
 	zip_name = $(name)-$(version)-$(git_branch)-$(git_hash).zip
 endif
-
-include_files = addon.xml LICENSE README.md resources/
-include_paths = $(patsubst %,$(name)/%,$(include_files))
-exclude_files = \*.new \*.orig \*.pyc \*.pyo
 zip_dir = $(name)/
 
 languages = $(filter-out en_gb, $(patsubst resources/language/resource.language.%, %, $(wildcard resources/language/*)))
@@ -74,7 +70,7 @@ profile:
 build: clean
 	@printf "$(white)=$(blue) Building new package$(reset)\n"
 	@rm -f ../$(zip_name)
-	cd ..; zip -r $(zip_name) $(include_paths) -x $(exclude_files)
+	@git archive --format zip --worktree-attributes -v -o ../$(zip_name) --prefix $(zip_dir) $(or $(shell git stash create), HEAD)
 	@printf "$(white)=$(blue) Successfully wrote package as: $(white)../$(zip_name)$(reset)\n"
 
 multizip: clean

--- a/addon.xml
+++ b/addon.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="plugin.video.redbull.tv" name="Red Bull TV" version="3.2.2" provider-name="piejanssens">
   <requires>
-    <import addon="script.module.dateutil" version="2.8.0" />
-    <import addon="script.module.routing" version="0.2.0" />
-    <import addon="xbmc.python" version="2.26.0" />
+    <import addon="script.module.dateutil" version="2.8.0"/>
+    <import addon="script.module.routing" version="0.2.0"/>
+    <import addon="xbmc.python" version="2.25.0"/>
   </requires>
   <extension point="xbmc.python.pluginsource" library="resources/lib/addon_entry.py">
     <provides>video</provides>


### PR DESCRIPTION
This simplifies the creation of the ZIP file as it uses .gitattributes for excluding common files.

It builds a ZIP file based on the working directory by using the current working directory as a stash.